### PR TITLE
fixed hardcoded locale and updated the python setup file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.venv/
 *.pyc
 *.aff
 *.dic

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .idea/
-.venv/
 *.pyc
 *.aff
 *.dic

--- a/jamspell/utils.cpp
+++ b/jamspell/utils.cpp
@@ -32,7 +32,7 @@ void SaveFile(const std::string& fileName, const std::string& data) {
 }
 
 TTokenizer::TTokenizer()
-    : Locale("en_US.utf-8")
+    : Locale(std::locale::classic())
 {
 }
 
@@ -135,7 +135,7 @@ uint64_t GetCurrentTimeMs() {
     return ms.count();
 }
 
-static const std::locale GLocale("en_US.UTF-8");
+static const std::locale GLocale(std::locale::classic());
 static const std::ctype<wchar_t>& GWctype = std::use_facet<std::ctype<wchar_t>>(GLocale);
 
 void ToLower(std::wstring& text) {

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 import os
 import sys
-from distutils.command.build import build
-from distutils.command.build_ext import build_ext
+from setuptools.command.build import build
+from setuptools.command.build_ext import build_ext
 from setuptools.command.install import install
-from distutils.spawn import find_executable
+from shutil import which as find_executable
 from setuptools import setup
 from setuptools.extension import Extension
 import subprocess


### PR DESCRIPTION
Changed the hardcoded en_US.utf-8 locale with the standard "C" locale, so the Python library does not require the locales package on Linux distros. Also updated the setup.py file to avoid using the deprecated distutils library.